### PR TITLE
Restore updated mod metadata

### DIFF
--- a/TobEx_AfterLife/TobEx_AfterLife.ini
+++ b/TobEx_AfterLife/TobEx_AfterLife.ini
@@ -1,43 +1,39 @@
-# Filename must be the same as tp2 name, placed at the same folder where .tp2 file is present, "UTF8 without BOM" encoding, everything is optional
+# Never copy this file from other mods, always use https://github.com/ALIENQuake/ProjectInfinity/wiki/Adding-metadata-for-mod
+# Filename must be the same as tp2 basename, placed in the same folder where
+# .tp2 file is located, use UTF8 (without BOM) encoding, everything is optional
 
 # ini section header is required to avoid false detection
 [Metadata]
 
-# Full name of the mod, without version number
+# Full name of the mod, without the list of supported games, without the version number, without 'Mod'
 Name = TobEx AfterLife
 
-# Author name or nick, don't use email address
+# Author name or nick, don't use an email address
 Author = Insomniator
 
 # Short description of the mod, main goals, features etc
-Description = AfterLife is TobEx fork with more bugfixes/tweaks of original Baldur's Gate II engine
+Description = AfterLife is a fork of TobEx with even more bugfixes and tweaks for the original BG2 engine.
 
-# Web address of mod readme file (filename is case-sensitive!) You can link to txt, md, html, pdf etc.
-Readme = https://spellholdstudios.github.io/TobEx_AfterLife/TobEx_AfterLife/documentation/readme.html
+# Web address of mod readme file (filename is case-sensitive!), comma-separated list. You can link to txt, md, html, pdf etc.
+Readme = https://spellhold-studios.github.io/readmes/tobex-afterlife/documentation/readme.html
 
-#  Web address of mod dedicated forum or forum thread
+# Web address of mod dedicated forum or forum thread 
 Forum = http://www.shsforums.net/topic/61072-tobex-afterlife/
 
-# Web address of mod Homepage
-Homepage = http://www.shsforums.net/files/file/1274-tobex-afterlife/
+# Web address of mod personal Homepage, no need to duplicate with a mod dedicated forum
+Homepage = https://spellhold-studios.github.io/
 
-# if you use Github.com, simply use https://github.com/AccountOrOrgName/RepositoryName
+# If you use GitHub.com, simply use https://github.com/AccountOrOrgName/RepositoryName (omit /releases)
 # read more about Delta Updates https://github.com/ALIENQuake/ProjectInfinity/wiki/Delta-Updates-for-mods-hosted-at-Github
-Download = https://github.com/SpellholdStudios/TobEx_AfterLife
+Download = https://github.com/Spellhold-Studios/TobEx-AfterLife
 
 # Type of LABELs used by the mod, read more here https://www.gibberlings3.net/forums/topic/32516-tutorial-what-is-label
 LabelType = GloballyUnique
 
 # Dynamic Install Order, use mod ID as tp2 name without file extension and `setup-` prefix
 
-# This mod must be installed *before* the mods listed after the keyword
+# This mod must be installed *before* those ModID listed below, comma-separated list:
 Before = bg2improvedgui
 
-# This mod must be installed *after* the mods listed after the keyword
-After = TobEx
-
-# The listed mods are required to be installed *before* this mod
-Require-Earlier = TobEx
-
-# The listed mods are required to be installed *after* this mod
-# Require-Later =
+# This mod must be installed *after* those ModID listed below, comma-separated list:
+After = tobex


### PR DESCRIPTION
The previously updated mod metadata was overwritten by an older version in https://github.com/Spellhold-Studios/TobEx-AfterLife/commit/8c54cf8718e77816fe1444f9a87c7b50b7bddba2. This restores the updated version.